### PR TITLE
PLENTY-341_SS_must_work_when_navi_turned_off

### DIFF
--- a/src/Middlewares/Middleware.php
+++ b/src/Middlewares/Middleware.php
@@ -74,13 +74,6 @@ class Middleware extends PlentyMiddleware
             return;
         }
 
-        $this->isSearchPage = strpos($request->getUri(), '/search') !== false;
-        $this->activeOnCatPage = !$this->isSearchPage && $this->pluginConfig->get(Plugin::CONFIG_NAVIGATION_ENABLED);
-
-        if (!$this->isSearchPage && !$this->activeOnCatPage) {
-            return;
-        }
-
         $this->eventDispatcher->listen(
             'IO.Resources.Import',
             function (ResourceContainer $container) {
@@ -104,6 +97,13 @@ class Middleware extends PlentyMiddleware
             },
             0
         );
+
+        $this->isSearchPage = strpos($request->getUri(), '/search') !== false;
+        $this->activeOnCatPage = !$this->isSearchPage && $this->pluginConfig->get(Plugin::CONFIG_NAVIGATION_ENABLED);
+
+        if (!$this->isSearchPage && !$this->activeOnCatPage) {
+            return;
+        }
 
         $this->eventDispatcher->listen(
             'IO.ctx.search',

--- a/tests/Middlewares/MiddlewareTest.php
+++ b/tests/Middlewares/MiddlewareTest.php
@@ -106,7 +106,9 @@ class MiddlewareTest extends TestCase
 
         $this->searchService->expects($this->once())->method('aliveTest')->willReturn(true);
 
-        $this->eventDispatcher->expects($this->never())->method('listen');
+        $this->eventDispatcher->expects($this->once())->method('listen')->with([
+            'IO.Resources.Import'
+        ]);
 
         $this->runBefore();
     }
@@ -264,8 +266,10 @@ class MiddlewareTest extends TestCase
 
         $middleware = new Middleware($pluginConfig, $searchServiceMock, $eventDispatcherMock);
 
-        // Ensure Findologic is not triggered.
-        $eventDispatcherMock->expects($this->never())->method('listen');
+        // Ensure snippets get loaded but Findologic is not triggered.
+        $eventDispatcherMock->expects($this->once())->method('listen')->with([
+            'IO.Resources.Import'
+        ]);
 
         $requestMock = $this->getMockBuilder(Request::class)
             ->disableOriginalConstructor()

--- a/tests/Middlewares/MiddlewareTest.php
+++ b/tests/Middlewares/MiddlewareTest.php
@@ -106,9 +106,7 @@ class MiddlewareTest extends TestCase
 
         $this->searchService->expects($this->once())->method('aliveTest')->willReturn(true);
 
-        $this->eventDispatcher->expects($this->once())->method('listen')->with([
-            'IO.Resources.Import'
-        ]);
+        $this->eventDispatcher->expects($this->once())->method('listen')->with('IO.Resources.Import');
 
         $this->runBefore();
     }
@@ -267,9 +265,7 @@ class MiddlewareTest extends TestCase
         $middleware = new Middleware($pluginConfig, $searchServiceMock, $eventDispatcherMock);
 
         // Ensure snippets get loaded but Findologic is not triggered.
-        $eventDispatcherMock->expects($this->once())->method('listen')->with([
-            'IO.Resources.Import'
-        ]);
+        $eventDispatcherMock->expects($this->once())->method('listen')->with('IO.Resources.Import');
 
         $requestMock = $this->getMockBuilder(Request::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
Always load Findologic snippets independent of navi config or search path